### PR TITLE
Store app & app_packages in separate directories

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -59,20 +59,25 @@ public class MainActivity extends AppCompatActivity {
     private Map<String, File> getPythonDirs() throws IOException {
         Map dirs = new HashMap<String, File>();
         File base = new File(getApplicationContext().getFilesDir().getAbsolutePath() + "/python/");
+
         // `stdlib` is used as PYTHONHOME.
         File stdlib = new File(base.getAbsolutePath() + "/stdlib/");
         ensureDir(stdlib);
         dirs.put("stdlib", stdlib);
+
         // `rubicon_java` is used to the required Rubicon module.
         File rubicon_java = new File(base.getAbsolutePath() + "/rubicon-java/");
         ensureDir(rubicon_java);
         dirs.put("rubicon_java", rubicon_java);
+
         // Put `user_code` into dirs so we can unpack the assets into it.
         dirs.put("user_code", new File(base.getAbsolutePath() + "/user_code/"));
+
         // `app` and `app_packages` store user code and user code dependencies,
         // respectively. These paths exist within the `python/` assets tree.
         File app = new File(base.getAbsolutePath() + "/user_code/app/");
         dirs.put("app", app);
+
         File app_packages = new File(base.getAbsolutePath() + "/user_code/app_packages/");
         dirs.put("app_packages", app_packages);
         return dirs;
@@ -81,23 +86,27 @@ public class MainActivity extends AppCompatActivity {
     private void unpackPython(Map<String, File> dirs) throws IOException {
         String myAbi = Build.SUPPORTED_ABIS[0];
         File pythonHome = dirs.get("stdlib");
+
         Log.d("unpackPython", "Unpacking Python with ABI " + myAbi + " to " + pythonHome.getAbsolutePath());
         unzipTo(new ZipInputStream(this.getAssets().open("pythonhome." + myAbi + ".zip")), pythonHome);
         makeExecutable(new File(pythonHome.getAbsolutePath() + "/bin/python3"));
         makeExecutable(new File(pythonHome.getAbsolutePath() + "/bin/python3.7"));
         File rubicon_java = dirs.get("rubicon_java");
+
         Log.d("unpackPython", "Unpacking rubicon-java to " + rubicon_java.getAbsolutePath());
         unzipTo(new ZipInputStream(this.getAssets().open("rubicon.zip")), rubicon_java);
         File userCodeDir = dirs.get("user_code");
+
         Log.d("unpackPython", "Unpacking Python assets to base dir " + userCodeDir.getAbsolutePath());
         unpackAssetPrefix(getAssets(), "python", userCodeDir);
     }
 
     private void setPythonEnvVars(String pythonHome) throws IOException, ErrnoException {
-        Os.setenv("RUBICON_LIBRARY", this.getApplicationInfo().nativeLibraryDir + "/librubicon.so", true);
         Log.v("python home", pythonHome);
         Context applicationContext = this.getApplicationContext();
         File cacheDir = applicationContext.getCacheDir();
+
+        Os.setenv("RUBICON_LIBRARY", this.getApplicationInfo().nativeLibraryDir + "/librubicon.so", true);
         Os.setenv("TMPDIR", cacheDir.getAbsolutePath(), true);
         Os.setenv("LD_LIBRARY_PATH", this.getApplicationInfo().nativeLibraryDir, true);
         Os.setenv("PYTHONHOME", pythonHome, true);
@@ -108,12 +117,14 @@ public class MainActivity extends AppCompatActivity {
         this.unpackPython(dirs);
         String pythonHome = dirs.get("stdlib").getAbsolutePath();
         this.setPythonEnvVars(pythonHome);
+
         // `app` is the last item in the sysPath list.
         String sysPath = (pythonHome + "/lib/python3.7/") + ":" + dirs.get("rubicon_java").getAbsolutePath() + ":"
                 + dirs.get("app_packages").getAbsolutePath() + ":" + dirs.get("app").getAbsolutePath();
         if (Python.init(pythonHome, sysPath, null) != 0) {
             throw new Exception("Unable to start Python interpreter.");
         }
+
         // Store the code in a file because Python.run() takes a filename.
         // We don't run app/__main__.py directly to avoid problems with package-relative
         // imports.

--- a/{{ cookiecutter.formal_name }}/briefcase.toml
+++ b/{{ cookiecutter.formal_name }}/briefcase.toml
@@ -1,9 +1,6 @@
 [paths]
-# app and app_packages *should* be separated...
-# app_path = "app/src/main/assets/python/app"
-# app_packages_path = "app/src/main/assets/python/app_packages"
-app_path = "app/src/main/assets/python"
-app_packages_path = "app/src/main/assets/python"
+app_path = "app/src/main/assets/python/app"
+app_packages_path = "app/src/main/assets/python/app_packages"
 support_path = "app"
 
 icon.round.48 = "app/src/main/res/mipmap-mdpi/ic_launcher_round.png"


### PR DESCRIPTION
Close #2

## Quality of this PR

This PR modifies a bunch of semi-unrelated Java code, and the Java code is somewhat messy. I'd prefer to leave this somewhat messy rather than block this change on Java cleanup.

## Testing

First of all, I can verify this moves the user code into `app`:

```
$ unzip -l 'android/Hello World/app/build/outputs/apk/debug/app-debug.apk' | grep app         
Archive:  android/Hello World/app/build/outputs/apk/debug/app-debug.apk
        6  1980-00-00 00:00   META-INF/androidx.appcompat_appcompat.version
       50  1980-00-00 00:00   META-INF/app_debug.kotlin_module
      159  1980-00-00 00:00   assets/python/app/README
       10  1980-00-00 00:00   assets/python/app/click_button_receive_log-0.0.1.dist-info/INSTALLER
      225  1980-00-00 00:00   assets/python/app/click_button_receive_log-0.0.1.dist-info/METADATA
        0  1980-00-00 00:00   assets/python/app/click_button_receive_log/__init__.py
      166  1980-00-00 00:00   assets/python/app/click_button_receive_log/__main__.py
     2612  1980-00-00 00:00   assets/python/app/click_button_receive_log/app.py
   445986  1980-00-00 00:00   assets/python/app/click_button_receive_log/resources/click_button_receive_log.icns
    13871  1980-00-00 00:00   assets/python/app/click_button_receive_log/resources/click_button_receive_log.ico
    14040  1980-00-00 00:00   assets/python/app/click_button_receive_log/resources/click_button_receive_log.png
       73  1980-00-00 00:00   assets/python/app_packages/README
```

In addition, the app still launches properly. See screenshots.

![Screenshot from 2020-03-26 18-46-16](https://user-images.githubusercontent.com/25457/77712974-7cec7100-6f92-11ea-942d-a5012bb21e62.png)

![Screenshot from 2020-03-26 18-45-17](https://user-images.githubusercontent.com/25457/77712985-81b12500-6f92-11ea-808a-b9b2e092dcea.png)
