### PR TITLE
Stop marking Python as executable

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/Helpers.kt
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/Helpers.kt
@@ -9,22 +9,6 @@ import java.util.zip.ZipInputStream
 
 const val TAG = "Helpers"
 
-fun makeExecutable(executable: File) {
-    if (executable.exists()) {
-        executable.setExecutable(true)
-        executable.setReadable(true)
-    } else {
-        throw IOException("Executable file is missing. Aborting.")
-    }
-    // See if magical restorecon saves the day
-    val pb =
-            ProcessBuilder("restorecon", executable.absolutePath)
-    println("Running restorecon...")
-    val process = pb.start()
-    val errCode = process.waitFor()
-    println("Restorecon finished. result=${errCode}")
-}
-
 fun unpackAssetPrefix(assets: AssetManager, assetPrefix: String, outputDir: File) {
     Log.d(TAG, "Clearing out path ${outputDir.absolutePath}")
     outputDir.deleteRecursively()

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -20,7 +20,6 @@ import java.util.zip.ZipInputStream;
 import org.beeware.rubicon.Python;
 import org.jetbrains.annotations.Nullable;
 
-import static org.beeware.android.HelpersKt.makeExecutable;
 import static org.beeware.android.HelpersKt.unpackAssetPrefix;
 import static org.beeware.android.HelpersKt.unzipTo;
 
@@ -89,8 +88,6 @@ public class MainActivity extends AppCompatActivity {
 
         Log.d("unpackPython", "Unpacking Python with ABI " + myAbi + " to " + pythonHome.getAbsolutePath());
         unzipTo(new ZipInputStream(this.getAssets().open("pythonhome." + myAbi + ".zip")), pythonHome);
-        makeExecutable(new File(pythonHome.getAbsolutePath() + "/bin/python3"));
-        makeExecutable(new File(pythonHome.getAbsolutePath() + "/bin/python3.7"));
         File rubicon_java = dirs.get("rubicon_java");
 
         Log.d("unpackPython", "Unpacking rubicon-java to " + rubicon_java.getAbsolutePath());


### PR DESCRIPTION
This removes the expectation from the template that `python3` and `python3.7` are present in the PYTHONHOME zip file.

It also removes the functionality for marking them executable. Note that the functionality for marking the binaries as executable was somewhat overwrought -- it calls the SELinux `restorecon` program in desperation. I think that's unnecessary. I'll test and fix the test suite app later, but I like the simplicity here for user apps for now.