### PR TITLE
Support apps with `-` in app name or bundle

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "module_name": "my_app",
   "bundle": "com.example",
-  "bundle_as_identifier": "com.example",
+  "package_name": "com.example",
   "app_name": "appname",
   "formal_name": "App Name",
   "_copy_without_render": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "module_name": "my_app",
   "bundle": "com.example",
+  "bundle_as_identifier": "com.example",
   "app_name": "appname",
   "formal_name": "App Name",
   "_copy_without_render": [

--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 29
     defaultConfig {
-        applicationId "{{ cookiecutter.bundle_as_identifier }}.{{ cookiecutter.module_name }}"
+        applicationId "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1

--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 29
     defaultConfig {
-        applicationId "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}"
+        applicationId "{{ cookiecutter.bundle_as_identifier }}.{{ cookiecutter.module_name }}"
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1

--- a/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{ cookiecutter.bundle_as_identifier }}.{{ cookiecutter.module_name }}">
+    package="{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application

--- a/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}">
+    package="{{ cookiecutter.bundle_as_identifier }}.{{ cookiecutter.module_name }}">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application


### PR DESCRIPTION
Relies on https://github.com/beeware/briefcase/pull/415

## Testing performed

I was able to successfully launch an app with a hyphenated app name; see testing notes on the briefcase PR.

## Upgrade danger

This change to the template means that it will require an unreleased version of briefcase. I'm fine with that for now, but I just wanted to give you a heads-up.