### PR TITLE
Remove special-casing of rubicon-java Python code

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -77,11 +77,6 @@ public class MainActivity extends AppCompatActivity {
         // We cache the stdlib by checking the contents of this file.
         paths.put("stdlib-last-filename", new File(base.getAbsolutePath() + "/stdlib.last-filename"));
 
-        // `rubicon_java` is used to the required Rubicon module.
-        File rubicon_java = new File(base.getAbsolutePath() + "/rubicon-java/");
-        ensureDir(rubicon_java);
-        paths.put("rubicon_java", rubicon_java);
-
         // Put `user_code` into paths so we can unpack the assets into it.
         paths.put("user_code", new File(base.getAbsolutePath() + "/user_code/"));
 
@@ -137,10 +132,6 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
             writer.close();
         }
 
-        File rubicon_java = paths.get("rubicon_java");
-        Log.d(TAG, "Unpacking rubicon-java to " + rubicon_java.getAbsolutePath());
-        unzipTo(new ZipInputStream(this.getAssets().open("rubicon.zip")), rubicon_java);
-
         File userCodeDir = paths.get("user_code");
         Log.d(TAG, "Unpacking Python assets to base dir " + userCodeDir.getAbsolutePath());
         unpackAssetPrefix(getAssets(), "python", userCodeDir);
@@ -153,6 +144,7 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
         Context applicationContext = this.getApplicationContext();
         File cacheDir = applicationContext.getCacheDir();
 
+        // Tell rubicon-java's Python code where to find the C library, to access it via ctypes.
         Os.setenv("RUBICON_LIBRARY", this.getApplicationInfo().nativeLibraryDir + "/librubicon.so", true);
         Os.setenv("TMPDIR", cacheDir.getAbsolutePath(), true);
         Os.setenv("LD_LIBRARY_PATH", this.getApplicationInfo().nativeLibraryDir, true);
@@ -167,7 +159,7 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
         this.setPythonEnvVars(pythonHome);
 
         // `app` is the last item in the sysPath list.
-        String sysPath = (pythonHome + "/lib/python3.7/") + ":" + paths.get("rubicon_java").getAbsolutePath() + ":"
+        String sysPath = (pythonHome + "/lib/python3.7/") + ":"
                 + paths.get("app_packages").getAbsolutePath() + ":" + paths.get("app").getAbsolutePath();
         if (Python.init(pythonHome, sysPath, null) != 0) {
             throw new Exception("Unable to start Python interpreter.");


### PR DESCRIPTION
This allows apps to bundle their desired version into app_packages.

## Testing performed

I built an app using this template

```
$ cat pyproject.toml| grep -C 2 template

[tool.briefcase.app.helloworld.android]
template = "/Users/paulproteus/projects/beeware/briefcase-android-gradle-template"
requires = [
    '/Users/paulproteus/projects/beeware/rubicon-java',
```

and I configured a custom rubicon-java library in `requires`, and I added a print statement to the custom rubicon-java library and both the following things happened.

- The app launched (demonstrating that rubicon-java exists), and

- The print statement executed, which I know because I found it in the log.

Here's a partial log printout.

```
06-14 17:11:24.706  4929  4946 D stdio   : Import rubicon...
06-14 17:11:25.100  4929  4946 D stdio   : hi asheesh! love, rubucon.java.jni
06-14 17:11:26.121  4929  4946 D stdio   : Python app launched & stored in Android Activity class
```

(pardon the typo of `rubucon` vs `rubicon`)