### PR TITLE
Cache all Python unpacking if app lastUpdateTime unchanged

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -110,7 +110,7 @@ FileInputStream(lastUpdateTimeFile), StandardCharsets.UTF_8));
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
             actualLastUpdateTime = String.valueOf(packageInfo.lastUpdateTime);
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "Unable to find package; using default actualLastUpdateTime: " + actualLastUpdateTime);
+            Log.e(TAG, "Unable to find package; using default actualLastUpdateTime");
         }
         if (storedLastUpdateTime != null && storedLastUpdateTime.equals(actualLastUpdateTime)) {
             Log.d(TAG, "unpackPython() complete: Exiting early due to lastUpdateTime match: " + storedLastUpdateTime);

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -1,6 +1,8 @@
 package org.beeware.android;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.system.ErrnoException;
@@ -92,6 +94,29 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void unpackPython(Map<String, File> paths) throws IOException {
+        // Try to find `lastUpdateTime` on disk; compare it to actual `lastUpdateTime` from package manager.
+        // https://developer.android.com/reference/android/content/pm/PackageInfo.html#lastUpdateTime
+        Context context = this.getApplicationContext();
+        File lastUpdateTimeFile = new File(context.getCacheDir(), "last-update-time");
+        String storedLastUpdateTime = null;
+        String actualLastUpdateTime = null;
+
+        if (lastUpdateTimeFile.exists()) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new
+FileInputStream(lastUpdateTimeFile), StandardCharsets.UTF_8));
+            storedLastUpdateTime = reader.readLine();
+        }
+        try {
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            actualLastUpdateTime = String.valueOf(packageInfo.lastUpdateTime);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Unable to find package; using default actualLastUpdateTime: " + actualLastUpdateTime);
+        }
+        if (storedLastUpdateTime != null && storedLastUpdateTime.equals(actualLastUpdateTime)) {
+            Log.d(TAG, "unpackPython() complete: Exiting early due to lastUpdateTime match: " + storedLastUpdateTime);
+            return;
+        }
+
         String myAbi = Build.SUPPORTED_ABIS[0];
         File pythonHome = paths.get("stdlib");
 
@@ -136,6 +161,12 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
         File userCodeDir = paths.get("user_code");
         Log.d(TAG, "Unpacking Python assets to base dir " + userCodeDir.getAbsolutePath());
         unpackAssetPrefix(getAssets(), "python", userCodeDir);
+        if (actualLastUpdateTime != null) {
+            Log.d(TAG, "Replacing old lastUpdateTime = " + storedLastUpdateTime + " with actualLastUpdateTime = " + actualLastUpdateTime);
+            BufferedWriter timeWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(lastUpdateTimeFile), StandardCharsets.UTF_8));
+            timeWriter.write(actualLastUpdateTime, 0, actualLastUpdateTime.length());
+            timeWriter.close();
+        }
         Log.d(TAG, "unpackPython() complete");
     }
 


### PR DESCRIPTION
This speeds up the **second** time you start an app.


Before change app first start time: 2.9 sec

```
06-28 22:21:32.940 12868 12868 D MainActivity: onCreate() start
06-28 22:21:35.839 12868 12868 D MainActivity: onCreate() complete
```

Before change app second start time: 2.9 sec

```
06-28 22:22:15.250 12894 12894 D MainActivity: onCreate() start
06-28 22:22:18.214 12894 12894 D MainActivity: onCreate() complete
```

After change app first start time: 3.1 sec

```
06-28 22:19:32.755 12794 12794 D MainActivity: onCreate() start
06-28 22:19:35.879 12794 12794 D MainActivity: onCreate() complete
```

After change app second start time: 1.9 sec

```
06-28 22:20:18.820 12823 12823 D MainActivity: onCreate() start
06-28 22:20:20.889 12823 12823 D MainActivity: onCreate() complete
```

App first start time is the time between "onCreate() start" and "onCreate() complete" being logged when executing the app via `rm -rf android && briefcase update android -rd && briefcase build android && briefcase run android -d @beePhone`.

App **second** start time is the time between "onCreate() start" and "onCreate() complete"  when I quit the app from the Android UI and then click the app icon from the launcher.

I have checked that "onCreate() start" is logged seemingly as soon as I click the app icon and that "onCreate() complete" is logged when the app shows its UI.

Note that even though it looks like this slows down the first launch, I think that was a fluke. The next time I tested it I got 2.8 seconds. This is pretty noisy, I'm afraid.

The use of `lastUpdateTime` scared me at first -- I wanted to use some deterministic APK hash or something. It's the system time at time of APK installation. I think it's completely OK to use it this way. Note that `briefcase run` currently always reinstalls the APK, even if that's not necessary, which means that for people developing an app, they'll never get to experience the speedy start behavior unless they click on the app from their Android device's launcher.