### PR TITLE
Set PYTHONUNBUFFERED in template

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -145,6 +145,10 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
         Context applicationContext = this.getApplicationContext();
         File cacheDir = applicationContext.getCacheDir();
 
+        // Set stdout and stderr to be unbuffered. We are overriding stdout/stderr and would
+        // prefer to avoid delays.
+        Os.setenv("PYTHONUNBUFFERED", "1", true);
+
         // Tell rubicon-java's Python code where to find the C library, to access it via ctypes.
         Os.setenv("RUBICON_LIBRARY", this.getApplicationInfo().nativeLibraryDir + "/librubicon.so", true);
         Os.setenv("TMPDIR", cacheDir.getAbsolutePath(), true);


### PR DESCRIPTION
In my opinion it is cleaner to do this in the template, rather than in rubicon-java.

See also https://github.com/beeware/rubicon-java/pull/45

## Testing performed

I created an app from this template, and it successfully booted and printed things. Good enough for me.