### PR TITLE
Include user app & app_packages pyc files

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -34,6 +34,12 @@ android {
             jniLibs.srcDirs = ['libs']
         }
     }
+    aaptOptions {
+        // Use default ignore rule *except* allow directories starting with _,
+        // so that pyc files in __pycache__ directories flow through into apps.
+        // https://android.googlesource.com/platform/frameworks/base/+/b41af58f49d371cedf041443d20a1893f7f6c840/tools/aapt/AaptAssets.cpp#60
+        ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Expected performance impact: Apps may start up faster, especially larger apps with more libraries than my trivial sample app.

Expected app size impact: `app` and `app_packages` will approximately double (in my limited testing, *.pyc files are about 100% the size of the corresponding *.py). That doesn't double the size of the app itself, since stdlib is bigger usually than `app` and `app_packages`.

## Testing performed

Performance test: Ambiguous, but doesn't seem to ruin anything. See below.

Smoke test passes: an app launches.

Functionality test: The APK now contains PYC files:

```
$ unzip -l 'android/Perf Test/app/build/outputs/apk/debug/app-debug.apk' | grep pyc | wc -l
      97
```

Whereas before this change, that would output 0.

Performance test:

Before this change, first start, 5.2 second start (uh is my computer getting slower?)

```
06-28 23:51:07.031 13795 13795 D MainActivity: onCreate() start
06-28 23:51:12.239 13795 13795 D MainActivity: onCreate() complete
```

Before this change, second start, 2.5 second start

```
06-28 23:51:49.951 13831 13831 D MainActivity: onCreate() start
06-28 23:51:52.241 13831 13831 D MainActivity: onCreate() complete
```

After this change, first start, 3.2 second start (uh the noise here is really big; there's no way this makes it ~40% faster)
```
06-28 23:53:06.459 13887 13887 D MainActivity: onCreate() start
06-28 23:53:09.654 13887 13887 D MainActivity: onCreate() complete
```

After this change, second start, 3 second start

```
06-28 23:54:07.333 13927 13927 D MainActivity: onCreate() start
06-28 23:54:10.361 13927 13927 D MainActivity: onCreate() complete
```

This will work nicely with #19 IMHO.
