### PR TITLE
Add Android Jetpack SwipeRefreshLayout

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation files('libs/rubicon.jar')
     implementation "androidx.core:core-ktx:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
This PR adds a dependency so that Toga's DetailedList widget can use SwipeToRefreshLayout. It's [documented in the official Android docs,](https://developer.android.com/training/swipe/add-swipe-interface) so I feel good relying on it.

It's only 36KB, based on visiting https://mvnrepository.com/artifact/androidx.swiperefreshlayout/swiperefreshlayout/1.1.0 , downloading the aar link on that page, and noticing the file is 36,200 bytes.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
