### PR TITLE
Added onActivityResult to MainActivity.java and IPythonApp.java

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
@@ -1,7 +1,10 @@
 package org.beeware.android;
 
+import android.content.Intent;
+
 public interface IPythonApp {
     void onCreate();
     void onResume();
     void onStart();
+    void onActivityResult(int requestCode, int resultCode, Intent data);
 }

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -1,6 +1,7 @@
 package org.beeware.android;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -261,6 +262,14 @@ FileInputStream(stdlibLastFilenamePath), StandardCharsets.UTF_8));
         super.onResume();
         pythonApp.onResume();
         Log.d(TAG, "onResume() complete");
+    }
+	
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        Log.d(TAG, "onActivityResult() start");
+        super.onActivityResult(requestCode, resultCode, data);
+        pythonApp.onActivityResult(requestCode, resultCode, data);
+        Log.d(TAG, "onActivityResult() complete");
     }
 
     private native boolean captureStdoutStderr();


### PR DESCRIPTION
This PR adds the method onActivityResult() in MainActivity.java and IPythonApp.java
This allows us to invoke Android Intents from Python and get the result back.

This template is used by following pull-request: https://github.com/beeware/toga/pull/1158

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
