### PR TITLE
Add CustomView & IView

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/CustomView.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/CustomView.java
@@ -1,0 +1,18 @@
+package org.beeware.android;
+
+public class CustomView extends android.view.View {
+    private IView view = null;
+
+    public CustomView(android.content.Context context) {
+        super(context);
+    }
+
+    public void setView(IView view) {
+        this.view = view;
+    }
+
+    public void onDraw(android.graphics.Canvas canvas) {
+        super.onDraw(canvas);
+        view.onDraw(canvas);
+    }
+}

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IView.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IView.java
@@ -1,0 +1,5 @@
+package org.beeware.android;
+
+public interface IView {
+    public void onDraw(android.graphics.Canvas canvas);
+}


### PR DESCRIPTION
## Summary

Implement fake-subclassing for the `android.graphics.View` class: Add `CustomView` class, which delegates `onDraw()` to `IView` interface, which can be implemented in Python.

## Action

Russell, if you're willing to review this and give me naming advice, and/or merge it into dev & 3.7 & 3.8 & 3.9, that would help as I build the toga_android `Canvas` widget.

## PR Checklist:
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Screenshot

Here is a picture of Python drawing a black circle on the canvas using this approach.

![image](https://user-images.githubusercontent.com/25457/116646601-56cf9800-a92d-11eb-9265-3de19263333a.png)

Here is a [full example app that uses it.](https://github.com/paulproteus/micro-custom-canvas/blob/main/microcustomcanvas/src/microcustomcanvas/app.py)

Here is a snippet to give you the idea.

```python
class PlatformIndependentCanvasWidget:
    @property
    def _impl(self):
        impl = getattr(self, '__impl', None)
        if impl is None:
            self.__impl = CanvasWidget()
        return self.__impl


class CanvasWidget:
    def __init__(self):
        super().__init__()
        self.custom_view = CustomView(toga_android.widgets.base._get_activity().getApplicationContext())
        self.custom_view.setView(MicroCustomCanvasView())

    @property
    def native(self):
        return self.custom_view


class MicroCustomCanvasView(IView):
    def onDraw(self, canvas):
        paint = Paint()
        paint.setColor(Color.BLACK)
        paint.setAntiAlias(True)
        paint.setStrokeWidth(5.0)
        canvas.drawOval(0.0, 0.0, 400.0, 400.0, paint)
```