### PR TITLE
Add java 8 language feature support

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -17,6 +17,10 @@ android {
             }
         }
     }
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled false

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/CustomView.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/CustomView.java
@@ -1,0 +1,18 @@
+package org.beeware.android;
+
+public class CustomView extends android.view.View {
+    private IView view = null;
+
+    public CustomView(android.content.Context context) {
+        super(context);
+    }
+
+    public void setView(IView view) {
+        this.view = view;
+    }
+
+    public void onDraw(android.graphics.Canvas canvas) {
+        super.onDraw(canvas);
+        view.onDraw(canvas);
+    }
+}

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IView.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IView.java
@@ -1,0 +1,5 @@
+package org.beeware.android;
+
+public interface IView {
+    public void onDraw(android.graphics.Canvas canvas);
+}


### PR DESCRIPTION
Without this patch, you end up with the following build failure.

   > Failed to transform artifact 'core.aar (androidx.core:core:1.6.0-alpha03)' to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /Users/paulproteus/.gradle/caches/transforms-2/files-2.1/06fa1a1e81ab0310f823a5246519dd3a/core-1.6.0-alpha03-runtime.jar.
         > Error while dexing.

After this patch, the build failure goes away.

I tested by creating a new app with `briefcase new`, then modifying the `template = ...` line to use this patched template. With the patch reverted, the build fails.

## Root (?) cause

A new version of [androidx.core was released yesterday](https://developer.android.com/jetpack/androidx/releases/core#1.6.0-alpha03) and it appears to be named in this error. I presume then that something in our Gradle configuration is willing to auto-update to higher and higher versions of androidx.core, presumably this:

> implementation "androidx.core:core-ktx:+"

I'm pretty sure I added that as part of some generic recommendation from Google, or maybe from some template for automatically generating Android apps' Gradle files, or maybe automation from Android Studio.

I recommend we not try hard to pin this. If this fails again for us in some way that we care about, we can try pinning. Personally I think we're probably well-served not to pin things yet and try to fix things as they arise.

It relates to our use of Kotlin, which I would also like to see us retain until we get more/other/bigger problems. We use Kotlin because `android/Helpers.kt` within the template is written in Kotlin. We could also port that to Java and/or turn it into a Maven dependency.

## PR Checklist:
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
