### PR TITLE
3.7 - Android build incompatible with system-installed cmake

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.formal_name }}/app/build.gradle
@@ -28,7 +28,6 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.6.0+"
         }
     }
     sourceSets {

--- a/{{ cookiecutter.formal_name }}/app/src/main/cpp/CMakeLists.txt
+++ b/{{ cookiecutter.formal_name }}/app/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,10 @@ cmake_minimum_required(VERSION 3.6.0)
 #)
 # =======================================================
 
+project(
+    {{ cookiecutter.formal_name }}
+)
+
 # Find the Android native logging library
 find_library(
     log-lib


### PR DESCRIPTION
- Add `project()` to our custom `CMakeLists.txt` for future Cmake support.
- Remove `version` of Cmake from `build.gradle` - this way gradle will not use system Cmake from PATH, instead it installs a new Cmake to `~/.briefcase/tools/android_sdk/cmake`.

Related issue: https://github.com/beeware/briefcase/issues/615

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
