### PR TITLE
Save and restore UI state

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
@@ -1,6 +1,7 @@
 package org.beeware.android;
 
 import android.content.Intent;
+import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -11,4 +12,6 @@ public interface IPythonApp {
     void onActivityResult(int requestCode, int resultCode, Intent data);
     public boolean onOptionsItemSelected(MenuItem menuitem);
     public boolean onPrepareOptionsMenu(Menu menu);
+    void onSaveInstanceState (Bundle outState);
+    void onRestoreInstanceState(Bundle savedInstanceState);
 }

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -294,6 +294,19 @@ public class MainActivity extends AppCompatActivity {
         return result;
     }
 
+    protected void onSaveInstanceState (Bundle outState) {
+        Log.d(TAG, "onSaveInstanceState() start");
+        pythonApp.onSaveInstanceState(outState);
+        Log.d(TAG, "onSaveInstanceState() complete");
+    }
+
+    protected void onRestoreInstanceState (Bundle savedInstanceState)
+    {
+        Log.d(TAG, "onRestoreInstanceState() start");
+        pythonApp.onRestoreInstanceState(savedInstanceState);
+        Log.d(TAG, "onRestoreInstanceState() complete");
+    }
+
     private native boolean captureStdoutStderr();
 
     static {


### PR DESCRIPTION
When the orientation of an Android device is changed from portrait to landscape or vice versa, Android restarts the app and the data previously displayed in the UI is lost. To prevent this, Android has 2 callback methods: onSaveInstanceState() and onRestoreInstanceState().

This PR allows the programmer to add these two callback methods in his toga.App code.
In onSaveInstanceState(), the programmer can then save the widget data and in onRestoreInstanceState(), he can restore the data after the app has restarted and the UI has been rebuilt.

This PR needs the PR https://github.com/beeware/toga/pull/1386

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
