### PR TITLE
Add multiple windows support for Android

### DIFF
--- a/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.formal_name }}/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="org.beeware.android.WinActivity" />
     </application>
 
 </manifest>

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
@@ -5,10 +5,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 public interface IPythonApp {
-    void onCreate();
-    void onResume();
-    void onStart();
-    void onActivityResult(int requestCode, int resultCode, Intent data);
-    public boolean onOptionsItemSelected(MenuItem menuitem);
-    public boolean onPrepareOptionsMenu(Menu menu);
+    public void getPythonWinById(WinActivity winActivity);
+    public void getMainWinId(MainActivity mainActivity);
 }

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonWin.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/IPythonWin.java
@@ -1,0 +1,16 @@
+package org.beeware.android;
+
+import android.content.Intent;
+import android.view.Menu;
+import android.view.MenuItem;
+
+public interface IPythonWin {
+    void onCreate();
+    void onResume();
+    void onStart();
+    void onDestory();
+    void setNative(WinActivity winActivity);
+    void onActivityResult(int requestCode, int resultCode, Intent data);
+    public boolean onOptionsItemSelected(MenuItem menuitem);
+    public boolean onPrepareOptionsMenu(Menu menu);
+}

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -13,8 +13,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.LinearLayout;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -37,10 +35,11 @@ import static org.beeware.android.Helpers.ensureDirExists;
 import static org.beeware.android.Helpers.unpackAssetPrefix;
 import static org.beeware.android.Helpers.unzipTo;
 
-public class MainActivity extends AppCompatActivity {
+import androidx.appcompat.app.AppCompatActivity;
 
+public class MainActivity extends WinActivity {
     // To profile app launch, use `adb -s MainActivity`; look for "onCreate() start" and "onResume() completed".
-    private String TAG = "MainActivity";
+
     private static IPythonApp pythonApp;
 
     /**
@@ -52,6 +51,10 @@ public class MainActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     public static void setPythonApp(IPythonApp app) {
         pythonApp = app;
+    }
+
+    public static IPythonApp getPythonApp(){
+        return pythonApp;
     }
 
     /**
@@ -234,12 +237,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     protected void onCreate(Bundle savedInstanceState) {
+        this.TAG = "MainActivity";
         Log.d(TAG, "onCreate() start");
         this.captureStdoutStderr();
         Log.d(TAG, "onCreate(): captured stdout/stderr");
         // Change away from the splash screen theme to the app theme.
         setTheme(R.style.AppTheme);
-        super.onCreate(savedInstanceState);
         LinearLayout layout = new LinearLayout(this);
         this.setContentView(layout);
         singletonThis = this;
@@ -250,49 +253,11 @@ public class MainActivity extends AppCompatActivity {
             Log.e(TAG, "Failed to create Python app", e);
             return;
         }
-        Log.d(TAG, "user code onCreate() start");
-        pythonApp.onCreate();
-        Log.d(TAG, "user code onCreate() complete");
-        Log.d(TAG, "onCreate() complete");
-    }
 
-    protected void onStart() {
-        Log.d(TAG, "onStart() start");
-        super.onStart();
-        pythonApp.onStart();
-        Log.d(TAG, "onStart() complete");
-    }
-
-    protected void onResume() {
-        Log.d(TAG, "onResume() start");
-        super.onResume();
-        pythonApp.onResume();
-        Log.d(TAG, "onResume() complete");
-    }
-
-    protected void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        Log.d(TAG, "onActivityResult() start");
-        super.onActivityResult(requestCode, resultCode, data);
-        pythonApp.onActivityResult(requestCode, resultCode, data);
-        Log.d(TAG, "onActivityResult() complete");
-    }
-
-    public boolean onOptionsItemSelected(MenuItem menuitem) {
-        boolean result;
-        Log.d(TAG, "onOptionsItemSelected() start");
-        result = pythonApp.onOptionsItemSelected(menuitem);
-        Log.d(TAG, "onOptionsItemSelected() complete");
-        return result;
-    }
-
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        boolean result;
-        Log.d(TAG, "onPrepareOptionsMenu() start");
-        result = pythonApp.onPrepareOptionsMenu(menu);
-        Log.d(TAG, "onPrepareOptionsMenu() complete");
-        return result;
-    }
+        pythonApp.getMainWinId(this);
+        System.out.println(pythonWinId);
+        super.onCreate(savedInstanceState);
+   }
 
     private native boolean captureStdoutStderr();
 

--- a/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/WinActivity.java
+++ b/{{ cookiecutter.formal_name }}/app/src/main/java/org/beeware/android/WinActivity.java
@@ -1,0 +1,99 @@
+package org.beeware.android;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.LinearLayout;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import {{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}.R;
+
+public class WinActivity extends AppCompatActivity {
+    // To profile app launch, use `adb -s MainActivity`; look for "onCreate() start" and "onResume() completed".
+    protected String TAG = "WindowActivity";
+    public IPythonWin pythonWin=null;
+    public void setPythonWin(IPythonWin win) {
+        pythonWin = win;
+    }
+
+    protected long pythonWinId = 0;
+    public void setPythonWinId(long id){
+        pythonWinId = id;
+    }
+    public long getPythonWinId(){
+        return pythonWinId;
+    }
+    protected void onCreate(Bundle savedInstanceState){
+        if (pythonWin == null) {
+            if (pythonWinId == 0) {
+                Log.d(TAG, "onCreate() start");
+                pythonWinId = (Long)
+                        getIntent().getSerializableExtra("pythonWinId");
+                setTheme(R.style.AppTheme);
+            }
+            MainActivity.getPythonApp().getPythonWinById(this);
+        }
+        super.onCreate(savedInstanceState);
+        Log.d(TAG, "user code onCreate() start");
+        pythonWin.setNative(this);
+        pythonWin.onCreate();
+        Log.d(TAG, "user code onCreate() complete");
+        Log.d(TAG, "onCreate() complete");
+    }
+
+    protected void onStart() {
+        Log.d(TAG, "onStart() start");
+        super.onStart();
+        pythonWin.onStart();
+        Log.d(TAG, "onStart() complete");
+    }
+
+    protected void onResume() {
+        Log.d(TAG, "onResume() start");
+        super.onResume();
+        pythonWin.onResume();
+        Log.d(TAG, "onResume() complete");
+    }
+
+    protected void onDestroy(){
+        super.onDestroy();
+        pythonWin.onDestory();
+    }
+
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        Log.d(TAG, "onActivityResult() start");
+        super.onActivityResult(requestCode, resultCode, data);
+        pythonWin.onActivityResult(requestCode, resultCode, data);
+        Log.d(TAG, "onActivityResult() complete");
+    }
+
+    public boolean onOptionsItemSelected(MenuItem menuitem) {
+        boolean result;
+        Log.d(TAG, "onOptionsItemSelected() start");
+        result = pythonWin.onOptionsItemSelected(menuitem);
+        Log.d(TAG, "onOptionsItemSelected() complete");
+        return result;
+    }
+
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        boolean result;
+        Log.d(TAG, "onPrepareOptionsMenu() start");
+        result = pythonWin.onPrepareOptionsMenu(menu);
+        Log.d(TAG, "onPrepareOptionsMenu() complete");
+        return result;
+    }
+
+    public void newActivity(long id){
+        System.out.println("new activity!");
+        startActivity(new Intent(this, WinActivity.class).putExtra("pythonWinId",id));
+    }
+
+    static {
+        System.loadLibrary("native-lib");
+    }
+}


### PR DESCRIPTION
With toga part: https://github.com/beeware/toga/pull/1394

What have been done:

- Codes in `MainActivity` about a window are moved to `WinActivity`, and `MainActivity` becomes the subclass of `WinActivity`;
- A listener object (`IPythonWin`) is now for a window but not for the whole application;
- Use intent to create new window, with the python id of the listener object (`IPythonWin`) passed, and then the id will be used to get (`IPythonApp.getPythonWinById`) the listener of the new window;
- Add `onDestory` event.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
