### PR TITLE
Bump target SDK to 32.

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.safe_formal_name }}/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
     defaultConfig {
         applicationId "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode {{ cookiecutter.version_code }}
         versionName "{{ cookiecutter.version }}"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
@@ -10,10 +10,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Launcher">
-        <activity android:name="org.beeware.android.MainActivity">
+        <activity
+            android:name="org.beeware.android.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
Bumps the Android Target SDK to 32.

This doesn't change the minimum supported SDK version (it remains Android 5.0/SDK 21); but it ensures that apps are built with the most recent SDK.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
