### PR TITLE
Increase minSdkVersion to 26

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.safe_formal_name }}/app/build.gradle
@@ -4,7 +4,11 @@ android {
     compileSdkVersion 32
     defaultConfig {
         applicationId "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
-        minSdkVersion 21
+
+        // JNI crashes may happen on older versions:
+        // https://github.com/beeware/rubicon-java/issues/74
+        minSdkVersion 26
+
         targetSdkVersion 32
         versionCode {{ cookiecutter.version_code }}
         versionName "{{ cookiecutter.version }}"
@@ -40,6 +44,12 @@ android {
         // so that pyc files in __pycache__ directories flow through into apps.
         // https://android.googlesource.com/platform/frameworks/base/+/b41af58f49d371cedf041443d20a1893f7f6c840/tools/aapt/AaptAssets.cpp#60
         ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
+    }
+    packagingOptions {
+        jniLibs {
+            // MainActivity requires libpython to be extracted as a separate file.
+            useLegacyPackaging true
+        }
     }
 }
 


### PR DESCRIPTION
Closes beeware/rubicon-java#74.

I also needed to add `useLegacyPackaging` to make sure that libpython continues to be extracted as a separate file, otherwise there was a startup crash similar to #42. Looks like this is one of the rare cases where changing `minSdkVersion` causes a change in the default settings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
