### PR TITLE
Add onConfigurationChanged to IPythonApp

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
@@ -10,8 +10,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Launcher">
-        <activity
-            android:configChanges="orientation|screenSize|keyboardHidden"
+      <!-- https://developer.android.com/guide/topics/resources/runtime-changes#HandlingTheChange -->
+      <activity
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:name="org.beeware.android.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/IPythonApp.java
@@ -1,6 +1,7 @@
 package org.beeware.android;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -9,6 +10,7 @@ public interface IPythonApp {
     void onResume();
     void onStart();
     void onActivityResult(int requestCode, int resultCode, Intent data);
-    public boolean onOptionsItemSelected(MenuItem menuitem);
-    public boolean onPrepareOptionsMenu(Menu menu);
+    void onConfigurationChanged(Configuration newConfig);
+    boolean onOptionsItemSelected(MenuItem menuitem);
+    boolean onPrepareOptionsMenu(Menu menu);
 }

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.system.ErrnoException;
@@ -276,6 +277,13 @@ public class MainActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
         pythonApp.onActivityResult(requestCode, resultCode, data);
         Log.d(TAG, "onActivityResult() complete");
+    }
+
+    public void onConfigurationChanged(Configuration newConfig) {
+        Log.d(TAG, "onConfigurationChanged() start");
+        super.onConfigurationChanged(newConfig);
+        pythonApp.onConfigurationChanged(newConfig);
+        Log.d(TAG, "onConfigurationChanged() complete");
     }
 
     public boolean onOptionsItemSelected(MenuItem menuitem) {


### PR DESCRIPTION
`configChanges` was added to AndroidManifest.xml a few weeks ago, which prevents the activity from being restarted when the screen rotates. However, Toga still doesn't update its layout after the rotation.

To fix this we'll need to implement `onConfigurationChanged`. The corresponding Toga PR is https://github.com/beeware/toga/pull/1507.

It's safe for the template update and the Toga update to be deployed separately:
* If only the template is updated, then Rubicon will log a warning about the unimplemented `onConfigurationChange` method, but otherwise everything is fine.
* If only Toga is updated, then `onConfigurationChange` will exist but will never be called.

Example of the previous behavior:

```
import toga
from toga.style import Pack
from toga.style.pack import COLUMN, ROW, LEFT, CENTER, RIGHT, TOP, BOTTOM


class Hello(toga.App):
    def startup(self):
        labels = [
            [toga.Label(text, style=Pack(flex=1)) for text in row]
            for row in [
                ["NW", "N", "NE"],
                ["W",  "X", "E"],
                ["SW", "S", "SE"],
            ]
        ]
        main_box = toga.Box(
            style=Pack(direction=COLUMN),
            children=[
                toga.Box(children=labels[0]),
                toga.Box(style=Pack(flex=1)),  # Spacer
                toga.Box(children=labels[1]),
                toga.Box(style=Pack(flex=1)),  # Spacer
                toga.Box(children=labels[2]),
            ]
        )

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()

        # Android backend doesn't support setting alignment until after native
        # widget creation.
        for row in labels:
            for label, text_align in zip(row, [LEFT, CENTER, RIGHT]):
                label.style.update(text_align=text_align)


def main():
    return Hello()
```

![portrait-good](https://user-images.githubusercontent.com/166954/175169750-ebf1bd3d-b79b-411b-8f8f-d59fb2de6690.png)

![landscape-bad](https://user-images.githubusercontent.com/166954/175169760-d1f9bdfc-c205-431f-a37d-6774bd9514b3.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
