### PR TITLE
Add a network security configuration to allow localhost HTTP

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Launcher">

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/res/xml/network_security_config.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Android doesn't allow HTTP connections by default. This is very inconvenient when dealing with localhost servers in the "positron"/"server-and-webview" application pattern.

This PR adds a stub network security configuration that allows cleartext HTTP, but *only* on 127.0.0.1 (and subdomains).

With this PR, both Positron examples in the Toga repo run without problems.

Fixes beeware/briefcase#916.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
