### PR TITLE
Add dynamic entry point for Android code.

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/build.gradle
+++ b/{{ cookiecutter.safe_formal_name }}/app/build.gradle
@@ -2,7 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.chaquo.python'
 
 android {
-    compileSdkVersion 32
+    // Android 13 == SDK Leevel 33. This number should generally be kept up to date with
+    // the most recent supported Android release.
+    compileSdkVersion 33
+    // The default NDK used by Gradle 4.2 is 21.4.7075529 (r21e); while still suppoerted, it
+    // isn't available on Github Actions. 25.1.8937393 (r25b) is the LTS as of Nov 2022f,
+    // supports Android 13, should be orwards compatible, and is installed on Github Actions.
+    ndkVersion "25.1.8937393"
     defaultConfig {
         applicationId "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
         versionCode {{ cookiecutter.version_code }}
@@ -13,6 +19,7 @@ android {
         // argument to `adb logcat`. This supports over 90% of active devices
         // (https://github.com/beeware/rubicon-java/issues/74).
         minSdkVersion 24
+        // This should gnerally match the compileSDKVersion from above.
         targetSdkVersion 33
 
         python {

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/formal_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -60,10 +60,13 @@ public class MainActivity extends AppCompatActivity {
             Python.start(new AndroidPlatform(this));
         }
         Python py = Python.getInstance();
-        Log.d(TAG, "Running main module");
-        py.getModule("runpy").callAttr("run_module", "{{ cookiecutter.module_name }}",
-                                       new Kwarg("run_name", "__main__"),
-                                       new Kwarg("alter_sys", true));
+        Log.d(TAG, "Running main module " + getString(R.string.main_module));
+        py.getModule("runpy").callAttr(
+            "run_module",
+            getString(R.string.main_module),
+            new Kwarg("run_name", "__main__"),
+            new Kwarg("alter_sys", true)
+        );
 
         userCode("onCreate");
         Log.d(TAG, "onCreate() complete");

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/res/values/briefcase.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/res/values/briefcase.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="main_module">{{ cookiecutter.module_name }}</string>
+</resources>

--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="app_name">{{ cookiecutter.formal_name }}</string>
+    <string name="formal_name">{{ cookiecutter.formal_name }}</string>
+    <string name="app_name">{{ cookiecutter.app_name }}</string>
 </resources>

--- a/{{ cookiecutter.safe_formal_name }}/briefcase.toml
+++ b/{{ cookiecutter.safe_formal_name }}/briefcase.toml
@@ -2,6 +2,7 @@
 [paths]
 app_path = "app/src/main/python"
 app_requirements_path = "app/requirements.txt"
+metadata_resource_path = "app/src/main/res/values/briefcase.xml"
 
 icon.round.48 = "app/src/main/res/mipmap-mdpi/ic_launcher_round.png"
 icon.round.72 = "app/src/main/res/mipmap-hdpi/ic_launcher_round.png"


### PR DESCRIPTION
A template to support testing in an Android Gradle project.

Introduces a new ``briefcase.xml`` metadata resource file that defines the main module entry point, and uses that resource file at runtime to start the app.

Also corrects an inconsistent usage of formal name/app name.

Refs https://github.com/beeware/briefcase/pull/962

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
