### PR TITLE
Make event loop enqueue a wakeup when it first starts

### DIFF
--- a/{{ cookiecutter.safe_formal_name }}/app/src/main/python-briefcase/rubicon/java/android_events.py
+++ b/{{ cookiecutter.safe_formal_name }}/app/src/main/python-briefcase/rubicon/java/android_events.py
@@ -91,6 +91,9 @@ class AndroidEventLoop(asyncio.SelectorEventLoop):
         )
         asyncio.events._set_running_loop(self)
 
+        # Schedule any tasks which were added before the loop started.
+        self.enqueue_android_wakeup_for_delayed_tasks()
+
     def enqueue_android_wakeup_for_delayed_tasks(self):
         """Ask Android to wake us up when delayed tasks are ready to be handled.
 


### PR DESCRIPTION
In https://github.com/beeware/toga/pull/1687 we use `add_background_task` before starting the event loop, to ensure the app is up and running before we start the test thread. But on Android, I found the task was never run.

This PR ensures that once the loop starts, any pending tasks are immediately scheduled.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
