### PR TITLE
Change Gradle distribution from "all" to "bin"

### DIFF
--- a/{{ cookiecutter.format }}/gradle/wrapper/gradle-wrapper.properties
+++ b/{{ cookiecutter.format }}/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jan 10 10:24:05 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip


### PR DESCRIPTION
When creating new apps, Android Studio uses the minimal "bin" distribution, which is much smaller. This is even more true in version 8.2, which we switched to recently (sizes in MB):

```
459     gradle-8.0-all
251     gradle-8.0-bin
632     gradle-8.2-all
137     gradle-8.2-bin
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
