### PR TITLE
Disable the Welcome to Gradle message

### DIFF
--- a/{{ cookiecutter.format }}/gradle.properties
+++ b/{{ cookiecutter.format }}/gradle.properties
@@ -11,6 +11,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+# Disable the Gradle welcome message that prints for gradle's first run.
+org.gradle.welcome=never
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
## Changes
- The message below prints when Gradle runs for the first time...which is every time in CI; squash this message since it is relevant.
```
Welcome to Gradle 8.2!

Here are the highlights of this release:
 - Kotlin DSL: new reference documentation, assignment syntax by default
 - Kotlin DSL is now the default with Gradle init
 - Improved suggestions to resolve errors in console output

For more details see https://docs.gradle.org/8.2/release-notes.html

Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details
```
This message showing in CI recently: https://github.com/beeware/.github/actions/runs/8013325227/job/21891321580?pr=99#step:28:392
This message not showing in CI any longer with this PR: https://github.com/beeware/briefcase-android-gradle-template/actions/runs/8013748771/job/21891259687?pr=85#step:25:391

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
