### PR TITLE
Add exit confirmation

### DIFF
--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -20,6 +20,9 @@ import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONException;
+import android.os.Handler;
+import android.widget.Toast;
+import android.app.AlertDialog;
 
 import {{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}.R;
 
@@ -29,6 +32,26 @@ public class MainActivity extends AppCompatActivity {
     // To profile app launch, use `adb -s MainActivity`; look for "onCreate() start" and "onResume() completed".
     private String TAG = "MainActivity";
     private static PyObject pythonApp;
+    private boolean doubleBackToExitPressedOnce = false;
+    
+    @Override
+    public void onBackPressed() {
+        if (doubleBackToExitPressedOnce) {
+            // super.onBackPressed(); // Exit the app
+            new AlertDialog.Builder(this)
+                .setTitle(R.string.exit_confirmation_title)
+                .setMessage(R.string.exit_confirmation_message)
+                .setPositiveButton(R.string.yes, (dialog, which) -> finish())
+                .setNegativeButton(R.string.no, null)
+                .show();
+            return;
+        }
+
+        this.doubleBackToExitPressedOnce = true;
+        Toast.makeText(this, R.string.press_back_again_to_exit, Toast.LENGTH_SHORT).show();
+
+        new Handler().postDelayed(() -> doubleBackToExitPressedOnce = false, 2000); // Reset after 2 seconds
+    }
 
     /**
      * This method is called by `app.__main__` over JNI in Python when the BeeWare

--- a/{{ cookiecutter.format }}/app/src/main/res/values-ar/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="formal_name">{{ cookiecutter.formal_name }}</string>
+    <string name="app_name">{{ cookiecutter.app_name }}</string>
+    <string name="exit_confirmation_title">تأكيد الخروج</string>
+    <string name="exit_confirmation_message">هل ترغب بالخروج من التطبيق؟</string>
+    <string name="yes">نعم</string>
+    <string name="no">لا</string>
+    <string name="press_back_again_to_exit">اضغط رجوع مرة أخرى للخروج</string>
+</resources>

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="formal_name">{{ cookiecutter.formal_name }}</string>
     <string name="app_name">{{ cookiecutter.app_name }}</string>
+    <string name="exit_confirmation_title">Exit Confirmation</string>
+    <string name="exit_confirmation_message">Would you like to exit the app?</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="press_back_again_to_exit">Press back again to exit</string>
 </resources>


### PR DESCRIPTION
# Description

This PR modifies the `onBackPressed()` behavior to implement a "double-tap to exit" confirmation for the app.

# Key Changes:

- Exit Confirmation Dialog: When the user presses the back button, instead of immediately exiting, a dialog is displayed:
- Title: "[String from `R.string.exit_confirmation_title`]"
- Message: "[String from `R.string.exit_confirmation_message`]"
- Options: "Yes" (exits the app) and "No" (cancels the exit)
- Toast Message: A brief message is shown: "[String from `R.string.press_back_again_to_exit`]" (e.g., "Press back again to exit")
### Double-Tap Logic:
- A flag (`doubleBackToExitPressedOnce`) is used to track if the back button has been pressed once.
- If pressed again within 2 seconds, the exit dialog appears.
- The flag is reset after 2 seconds using a Handler.

# Purpose:

This change prevents accidental exits from the app. It gives the user a chance to confirm their intention to leave, improving the overall user experience.

# Testing:

- Launch the app.
- Press the back button once. Verify the toast message appears.
- Press the back button again within 2 seconds. Verify the exit confirmation dialog appears.
- Test both "Yes" and "No" options in the dialog.


<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
