### PR TITLE
Update to Chaquopy 16.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
       fail-fast: false
       matrix:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         framework: [ "toga" ]

--- a/{{ cookiecutter.format }}/build.gradle
+++ b/{{ cookiecutter.format }}/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath 'com.chaquo.python:gradle:15.0.1'
+        classpath 'com.chaquo.python:gradle:16.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This adds support for Python 3.13. I haven't written the release notes yet, but everything is fully tested and live on Maven Central.

The current stable version of toga_android doesn't work on Python 3.13 (https://github.com/beeware/toga/issues/2907), but the error message doesn't make it clear that this can be fixed by changing the Python version:
```
AttributeError: 'AndroidSelector' object has no attribute '_key_from_fd'
```

With the current stable version of Briefcase, it doesn't get as far as running the app, and it displays a much clearer message:
```
Invalid Python version '3.13'. Available versions are [3.8, 3.9, 3.10, 3.11, 3.12].
```

So I think we should do a Toga release before the next Briefcase release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
