### PR TITLE
Allow configuration of pip options

### DIFF
--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -23,13 +23,12 @@ android {
         python {
             version "{{ cookiecutter.python_version|py_tag }}"
 
-
             pip {
                 install "-r", "requirements.txt"
 
                 def f = new File(project.projectDir, "pip-options.txt")
                 def pipOptions = f.isFile() ? f.getText("utf-8").split("\n") : []
-                pipOptions = pipOptions.findAll { !it.startsWith("#") && !it.isBlank() }
+                pipOptions = pipOptions.findAll { !it.isBlank() }
                 options(*pipOptions)
             }
             {%- if cookiecutter.extract_packages %}

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -22,8 +22,15 @@ android {
 
         python {
             version "{{ cookiecutter.python_version|py_tag }}"
+
+
             pip {
                 install "-r", "requirements.txt"
+
+                def f = new File(project.projectDir, "pip-options.txt")
+                def pipOptions = f.isFile() ? f.getText("utf-8").split("\n") : []
+                pipOptions = pipOptions.findAll { !it.startsWith("#") && !it.isBlank() }
+                options(*pipOptions)
             }
             {%- if cookiecutter.extract_packages %}
             extractPackages {{ cookiecutter.extract_packages }}

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -27,7 +27,7 @@ android {
                 install "-r", "requirements.txt"
 
                 def f = new File(project.projectDir, "pip-options.txt")
-                def pipOptions = f.isFile() ? f.getText("utf-8").split("\n") : []
+                def pipOptions = f.getText("utf-8").split("\n")
                 pipOptions = pipOptions.findAll { !it.isBlank() }
                 options(*pipOptions)
             }

--- a/{{ cookiecutter.format }}/app/pip-options.txt
+++ b/{{ cookiecutter.format }}/app/pip-options.txt
@@ -1,0 +1,3 @@
+# Briefcase may overwrite the contents of this file to configure Chaquopy
+# pip options as required by the app configuration.
+# Empty lines and lines starting with # will be ignored

--- a/{{ cookiecutter.format }}/app/pip-options.txt
+++ b/{{ cookiecutter.format }}/app/pip-options.txt
@@ -1,3 +1,0 @@
-# Briefcase may overwrite the contents of this file to configure Chaquopy
-# pip options as required by the app configuration.
-# Empty lines and lines starting with # will be ignored

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -5,6 +5,7 @@ target_version = "0.3.15"
 [paths]
 app_path = "app/src/main/python"
 app_requirements_path = "app/requirements.txt"
+app_requirement_installer_args_path = "app/pip-options.txt"
 metadata_resource_path = "app/src/main/res/values/briefcase.xml"
 
 icon.round.48 = "app/src/main/res/mipmap-mdpi/ic_launcher_round.png"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Related to https://github.com/beeware/briefcase/issues/1270

This PR is roughly similar to https://github.com/beeware/briefcase-linux-flatpak-template/pull/52, except that while the Flatpak PR claims to "decouple" pip install from requirement installation, that isn't as easy to do for the Android template, so far as I can tell. The implementation matches @mhsmith's recommendation from the linked issue to write the options to a text file to be read in `build.gradle`.

I've tested this by building an app with the template without any addition pip options, as well as by using [Briefcase from this PR which adds the new `requirement_installer_args` configuration](https://github.com/beeware/briefcase/pull/2059) and is now updated to support this `pip-options.txt` file. You could also just checkout this branch locally and use the template that way, with manual modifications to `pip-options.txt` to verify that it works (i.e., that the options are applied).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
