### PR TITLE
[1876] fix: Adds app name character escaping

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,9 @@
 {
   "format": "gradle",
   "formal_name": "App Name",
-  "safe_formal_name": "{{ cookiecutter.formal_name|escape_gradle }}",
-  "app_name": "{{ cookiecutter.formal_name|lower|replace(' ', '-')|escape_gradle }}",
-  "module_name": "{{ cookiecutter.app_name|replace('-', '_')|escape_gradle }}",
+  "safe_formal_name": "{{ cookiecutter.formal_name }}",
+  "app_name": "{{ cookiecutter.formal_name|lower|replace(' ', '-') }}",
+  "module_name": "{{ cookiecutter.app_name|replace('-', '_') }}",
   "bundle": "com.example",
   "package_name": "{{ cookiecutter.bundle|replace('-', '_') }}",
   "primary_color": "#008577",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,9 @@
 {
   "format": "gradle",
   "formal_name": "App Name",
-  "safe_formal_name": "{{ cookiecutter.formal_name }}",
-  "app_name": "{{ cookiecutter.formal_name|lower|replace(' ', '-') }}",
-  "module_name": "{{ cookiecutter.app_name|replace('-', '_') }}",
+  "safe_formal_name": "{{ cookiecutter.formal_name|escape_gradle }}",
+  "app_name": "{{ cookiecutter.formal_name|lower|replace(' ', '-')|escape_gradle }}",
+  "module_name": "{{ cookiecutter.app_name|replace('-', '_')|escape_gradle }}",
   "bundle": "com.example",
   "package_name": "{{ cookiecutter.bundle|replace('-', '_') }}",
   "primary_color": "#008577",
@@ -35,6 +35,7 @@
   ],
   "_extensions": [
     "briefcase.integrations.cookiecutter.PythonVersionExtension",
-    "briefcase.integrations.cookiecutter.XMLExtension"
+    "briefcase.integrations.cookiecutter.XMLExtension",
+    "briefcase.integrations.cookiecutter.GradleEscape"
   ]
 }

--- a/{{ cookiecutter.format }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.format }}/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name|escape_gradle }}.fileprovider"
+            android:authorities="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/{{ cookiecutter.format }}/app/src/main/AndroidManifest.xml
+++ b/{{ cookiecutter.format }}/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.fileprovider"
+            android:authorities="{{ cookiecutter.bundle }}.{{ cookiecutter.app_name|escape_gradle }}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="formal_name">{{ cookiecutter.formal_name }}</string>
-    <string name="app_name">{{ cookiecutter.app_name }}</string>
+    <string name="formal_name">{{ cookiecutter.formal_name|escape_gradle }}</string>
+    <string name="app_name">{{ cookiecutter.app_name|escape_gradle }}</string>
 </resources>

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="formal_name">{{ cookiecutter.formal_name|escape_xml }}</string>
+    <string name="formal_name">"{{ cookiecutter.formal_name|escape_xml }}"</string>
     <string name="app_name">{{ cookiecutter.app_name }}</string>
 </resources>

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="formal_name">{{ cookiecutter.formal_name|escape_gradle }}</string>
-    <string name="app_name">{{ cookiecutter.app_name|escape_gradle }}</string>
+    <string name="formal_name">{{ cookiecutter.formal_name }}</string>
+    <string name="app_name">{{ cookiecutter.app_name }}</string>
 </resources>

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="formal_name">"{{ cookiecutter.formal_name|escape_xml }}"</string>
+    <string name="formal_name">"{{ cookiecutter.formal_name }}"</string>
     <string name="app_name">{{ cookiecutter.app_name }}</string>
 </resources>

--- a/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
+++ b/{{ cookiecutter.format }}/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="formal_name">{{ cookiecutter.formal_name }}</string>
+    <string name="formal_name">{{ cookiecutter.formal_name|escape_xml }}</string>
     <string name="app_name">{{ cookiecutter.app_name }}</string>
 </resources>

--- a/{{ cookiecutter.format }}/settings.gradle
+++ b/{{ cookiecutter.format }}/settings.gradle
@@ -1,2 +1,2 @@
 include ':app'
-rootProject.name='{{ cookiecutter.safe_formal_name }}'
+rootProject.name='{{ cookiecutter.safe_formal_name|escape_gradle }}'


### PR DESCRIPTION
Adds GradeEscape extension to app name usage.

- User-entered data should be appropriately escaped in Gradle, rather than break the resulting template

Fixes beeware/briefcase#1876

## PR Checklist:
- [x] ~~All new features have been tested~~
- [x] ~~All new features have been documented~~
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
