### PR TITLE
Add additional environment variables

### DIFF
--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -16,9 +16,11 @@ import com.chaquo.python.PyObject;
 import com.chaquo.python.Python;
 import com.chaquo.python.android.AndroidPlatform;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.json.JSONException;
 
 import {{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}.R;
@@ -74,6 +76,20 @@ public class MainActivity extends AppCompatActivity {
                     List<PyObject> sysArgv = py.getModule("sys").get("argv").asList();
                     for (int i = 0; i < argvJson.length(); i++) {
                         sysArgv.add(PyObject.fromJava(argvJson.getString(i)));
+                    }
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            String envStr = getIntent().getStringExtra("org.beeware.ENV");
+            if (envStr != null) {
+                try {
+                    JSONObject envJson = new JSONObject(envStr);
+                    for (Iterator<String> it = envJson.keys(); it.hasNext(); ) {
+                        String key = it.next();
+                        String value = envJson.getString(key);
+                        py.getModule("os").get("environ").callAttr("__setitem__", key, value);
                     }
                 } catch (JSONException e) {
                     throw new RuntimeException(e);

--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -60,13 +60,13 @@ public class MainActivity extends AppCompatActivity {
         this.setContentView(layout);
         singletonThis = this;
 
-        String envStr = getIntent().getStringExtra("org.beeware.ENV");
-        if (envStr != null) {
+        String environStr = getIntent().getStringExtra("org.beeware.ENVIRON");
+        if (environStr != null) {
             try {
-                JSONObject envJson = new JSONObject(envStr);
-                for (Iterator<String> it = envJson.keys(); it.hasNext(); ) {
+                JSONObject environJson = new JSONObject(environStr);
+                for (Iterator<String> it = environJson.keys(); it.hasNext(); ) {
                     String key = it.next();
-                    String value = envJson.getString(key);
+                    String value = environJson.getString(key);
                     Os.setenv(key, value, true);
                 }
             } catch (JSONException e) {


### PR DESCRIPTION
This PR allows briefcase to pass environment variables to the app via `org.beeware.ENV`, which are added in `sys.environ`. 

The feature can be used, for example, to configure a remote debugger (see https://github.com/beeware/briefcase/pull/2173). The use of `org.beeware.ARGV` for this purpose is not optimal, as ARGV should pass arguments from the user and briefcase parameters should not influence them.

It is not yet clear whether the environment variables should really be used for the remote debugger. This only makes sense if it is possible on all platforms. The tests on iOS are still pending, so this PR is marked as a draft for now.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
