### PR TITLE
Allow min, compile and target SDK versions to be configurable.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,8 @@
   "version": "1.0",
   "version_code": "10000",
   "python_version": "3.X.0",
+  "min_os_version": "24",
+  "target_sdk_version": "34",
   "extract_packages" : "",
   "build_gradle_dependencies": "",
   "build_gradle_extra_content": "",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,7 +17,7 @@
   "version_code": "10000",
   "python_version": "3.X.0",
   "min_os_version": "24",
-  "target_sdk_version": "34",
+  "target_os_version": "34",
   "extract_packages" : "",
   "build_gradle_dependencies": "",
   "build_gradle_extra_content": "",

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.chaquo.python'
 android {
     // This number should generally be kept up to date with
     // the most recent supported Android release.
-    compileSdkVersion {{ cookiecutter.target_sdk_version }}
+    compileSdkVersion {{ cookiecutter.target_os_version }}
 
     namespace "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
 
@@ -18,7 +18,7 @@ android {
         // argument to `adb logcat`. This supports over 97% of active devices (as of sept 2024).
         minSdkVersion {{ cookiecutter.min_os_version }}
         // This should generally match the compileSDKVersion from above.
-        targetSdkVersion {{ cookiecutter.target_sdk_version }}
+        targetSdkVersion {{ cookiecutter.target_os_version }}
 
         python {
             version "{{ cookiecutter.python_version|py_tag }}"

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.chaquo.python'
 
 android {
-    // Android 14 == SDK Level 34. This number should generally be kept up to date with
+    // This number should generally be kept up to date with
     // the most recent supported Android release.
-    compileSdkVersion 34
+    compileSdkVersion {{ cookiecutter.target_sdk_version }}
 
     namespace "{{ cookiecutter.package_name }}.{{ cookiecutter.module_name }}"
 
@@ -16,9 +16,9 @@ android {
 
         // Briefcase currently requires API Level 24 for the `pidof` command, and the `--pid`
         // argument to `adb logcat`. This supports over 97% of active devices (as of sept 2024).
-        minSdkVersion 24
+        minSdkVersion {{ cookiecutter.min_os_version }}
         // This should generally match the compileSDKVersion from above.
-        targetSdkVersion 34
+        targetSdkVersion {{ cookiecutter.target_sdk_version }}
 
         python {
             version "{{ cookiecutter.python_version|py_tag }}"


### PR DESCRIPTION
Exposes `minSdkVersion` and  `targetSdkVersion` as variables that can be configured, and sets `compileSdkVersion` to the same value as the `targetSdkVersion`.

Refs beeware/briefcase#2233.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
