### PR TITLE
Added support for intercepting key events

### DIFF
--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.LinearLayout;
@@ -176,6 +177,17 @@ public class MainActivity extends AppCompatActivity {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         userCode("onRequestPermissionsResult", requestCode, permissions, grantResults);
         Log.d(TAG, "onRequestPermissionsResult() complete");
+    }
+
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        Log.d(TAG, "dispatchKeyEvent() start");
+        PyObject pyResult = userCode("dispatchKeyEvent", event);
+        boolean result = (pyResult == null) ? false : pyResult.toBoolean();
+        if (!result) {
+            result = super.dispatchKeyEvent(event);
+        }
+        Log.d(TAG, "dispatchKeyEvent() complete");
+        return result;
     }
 
     private PyObject userCode(String methodName, Object... args) {


### PR DESCRIPTION
This commit overrides the [`dispatchKeyEvent()`](https://developer.android.com/reference/android/app/Activity#dispatchKeyEvent(android.view.KeyEvent)) method of the `MainActivity` class, allowing Android applications to intercept key events.

The main need for this change is to allow applications to intercept events from hardware buttons, either in the device itself or connected peripherals, e.g. a Bluetooth headset.

Fixes #100

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
