### PR TITLE
Dynamic setting of `extractPackages`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,6 @@
   "python_version": "3.X.0",
   "min_os_version": "24",
   "target_os_version": "35",
-  "extract_packages" : "",
   "build_gradle_dependencies": "",
   "build_gradle_extra_content": "",
   "android_manifest_attrs_extra_content": "",

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -33,6 +33,12 @@ android {
             }
             {%- if cookiecutter.extract_packages %}
             extractPackages {{ cookiecutter.extract_packages }}
+            {%- else %}
+            def f = new File(project.projectDir, "extract-packages.txt")
+            def packages = f.exists() ? f.readLines("utf-8")
+                        .collect { it.trim() }
+                        .findAll { !it.isBlank() } : []
+            extractPackages(*packages)
             {%- endif %}
         }
         ndk {

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -31,15 +31,11 @@ android {
                 pipOptions = pipOptions.findAll { !it.isBlank() }
                 options(*pipOptions)
             }
-            {%- if cookiecutter.extract_packages %}
-            extractPackages {{ cookiecutter.extract_packages }}
-            {%- else %}
             def f = new File(project.projectDir, "extract-packages.txt")
-            def packages = f.exists() ? f.readLines("utf-8")
+            def packages = f.readLines("utf-8")
                         .collect { it.trim() }
-                        .findAll { !it.isBlank() } : []
+                        .findAll { !it.isBlank() }
             extractPackages(*packages)
-            {%- endif %}
         }
         ndk {
             {% if cookiecutter.python_version|py_tag in ["3.9", "3.10", "3.11"] %}

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,6 +7,7 @@ app_path = "app/src/main/python"
 app_requirements_path = "app/requirements.txt"
 app_requirement_installer_args_path = "app/pip-options.txt"
 metadata_resource_path = "app/src/main/res/values/briefcase.xml"
+metadata_extract_packages_path = "app/extract-packages.txt"
 
 icon.round.48 = "app/src/main/res/mipmap-mdpi/ic_launcher_round.png"
 icon.round.72 = "app/src/main/res/mipmap-hdpi/ic_launcher_round.png"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,6 +1,6 @@
 # Generated using Python {{ cookiecutter.python_version }}
 [briefcase]
-target_version = "0.3.26"
+target_version = "0.3.27"
 
 [paths]
 app_path = "app/src/main/python"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,13 +1,13 @@
 # Generated using Python {{ cookiecutter.python_version }}
 [briefcase]
-target_version = "0.3.15"
+target_version = "0.3.26"
 
 [paths]
 app_path = "app/src/main/python"
 app_requirements_path = "app/requirements.txt"
 app_requirement_installer_args_path = "app/pip-options.txt"
 metadata_resource_path = "app/src/main/res/values/briefcase.xml"
-metadata_extract_packages_path = "app/extract-packages.txt"
+extract_packages_path = "app/extract-packages.txt"
 
 icon.round.48 = "app/src/main/res/mipmap-mdpi/ic_launcher_round.png"
 icon.round.72 = "app/src/main/res/mipmap-hdpi/ic_launcher_round.png"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR adds the ability to dynamically set packages to be extracted via `extractPackages` via a `extract-packages.txt` file. This adds the possibility in briefcase to define these packages in `briefcase build` and not in `briefcase create`.

<!--- What problem does this change solve? -->
To set breakpoints when debugging via VSCode (see https://github.com/beeware/briefcase/pull/2351), the packages to be debugged must first be extracted so that debugpy can map the breakpoints set on the host PC to those on the Android device via the path mappings. For this mapping, however, the .py files must be located on the Android file system and therefore be extracted. However, since this extraction leads to a longer startup time, this should only be done for debug builds via `briefcase build --debug`. Currently it is only possible to specify `extractPackages` during `briefcase create`. But `briefcase create` has no `--debug` option, and I dont think it is worth adding it to create.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

briefcase-repo: https://github.com/timrid/briefcase
briefcase-ref: feature/debugger-support-android

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
