### PR TITLE
Route the Android hardware back button to the Python app

### DIFF
--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -174,6 +174,21 @@ public class MainActivity extends AppCompatActivity {
         Log.d(TAG, "onConfigurationChanged() complete");
     }
 
+    @Override
+    public void onBackPressed() {
+        Log.d(TAG, "onBackPressed() start");
+        // Give the Python app a chance to handle the hardware/gesture back
+        // button. If it returns a truthy value the event is consumed; otherwise
+        // fall back to the platform default (finishing the activity).
+        PyObject pyResult = userCode("onBackPressed");
+        if (pyResult != null && pyResult.toBoolean()) {
+            Log.d(TAG, "onBackPressed() handled by Python");
+            return;
+        }
+        super.onBackPressed();
+        Log.d(TAG, "onBackPressed() complete");
+    }
+
     public boolean onOptionsItemSelected(MenuItem menuitem) {
         Log.d(TAG, "onOptionsItemSelected() start");
         PyObject pyResult = userCode("onOptionsItemSelected", menuitem);


### PR DESCRIPTION
Companion to **beeware/toga#4460**. Refs beeware/toga#1623.

### What this does

Overrides `MainActivity.onBackPressed()` to give the embedded Python app a chance
to handle the hardware/gesture **Back** button, via the existing `userCode(...)`
delegation mechanism already used for the other activity lifecycle callbacks:

```java
@Override
public void onBackPressed() {
    PyObject pyResult = userCode("onBackPressed");
    if (pyResult != null && pyResult.toBoolean()) {
        return;                 // consumed by the Python app
    }
    super.onBackPressed();      // otherwise, platform default (finish activity)
}
```

If the Python app doesn't implement `onBackPressed` (or there is no Python app,
e.g. the support testbed), `userCode` returns `null` and behavior is unchanged —
so this is safe on its own.

This lets Toga map the back button onto `App.request_exit()` / `App.on_exit`
(see the companion toga PR), so an app's exit handler is honored — including
using Back to navigate within the app — instead of the activity being silently
finished. This is the template half of beeware/toga#1623.

### Notes

- Uses the legacy `onBackPressed()` override (works on all supported API levels,
  minSdk 24+, with the default `android:enableOnBackInvokedCallback="false"`).
  Migrating to the predictive-back `OnBackPressedDispatcher` API (which would
  also entail bumping `appcompat` from 1.0.2) is a reasonable follow-up; kept out
  of scope here to keep the change minimal and low-risk.

### Testing

Built and run via Briefcase against the companion toga branch on a physical
device (Android, API ≥ 26): Back delegates to the Python handler, which returns
to consume the event (in-app navigation) or falls through to `super` for the
default finish. Lifecycle logs confirm `onBackPressed() start` →
`onBackPressed() handled by Python` (or the exit lifecycle).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.8
