### PR TITLE
Update target API level to 36, and Android Gradle plugin to 9.3.1

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
   "version_code": "10000",
   "python_version": "3.X.0",
   "min_os_version": "24",
-  "target_os_version": "35",
+  "target_os_version": "36",
   "build_gradle_dependencies": "",
   "ndk": {"abi_filters": null},
   "build_gradle_extra_content": "",

--- a/{{ cookiecutter.format }}/app/build.gradle
+++ b/{{ cookiecutter.format }}/app/build.gradle
@@ -66,6 +66,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "androidx.appcompat:appcompat:1.7.1"
+
 {%- if cookiecutter.build_gradle_dependencies -%}
 {%- for lib in cookiecutter.build_gradle_dependencies.implementation %}
     implementation "{{ lib }}"

--- a/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
+++ b/{{ cookiecutter.format }}/app/src/main/java/org/beeware/android/MainActivity.java
@@ -8,9 +8,16 @@ import android.system.ErrnoException;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.LinearLayout;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
+import androidx.activity.EdgeToEdge;
+import androidx.activity.SystemBarStyle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.chaquo.python.Kwarg;
 import com.chaquo.python.PyException;
@@ -56,9 +63,21 @@ public class MainActivity extends AppCompatActivity {
         // Change away from the splash screen theme to the app theme.
         setTheme(R.style.AppTheme);
         super.onCreate(savedInstanceState);
-        LinearLayout layout = new LinearLayout(this);
-        this.setContentView(layout);
         singletonThis = this;
+
+        EdgeToEdge.enable(this, SystemBarStyle.dark(getColor(R.color.colorPrimaryDark)));
+        View layout = new FrameLayout(this);
+        setContentView(
+            layout,
+            new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        );
+
+        // setContentView below has given the FrameLayout a position and size that
+        // doesn't overlap anything, so use that as the parent of the app's content.
+        findViewById(android.R.id.content).setId(View.NO_ID);
+        layout.setId(android.R.id.content);
 
         String environStr = getIntent().getStringExtra("org.beeware.ENVIRON");
         if (environStr != null) {
@@ -111,6 +130,44 @@ public class MainActivity extends AppCompatActivity {
 
         userCode("onCreate");
         Log.d(TAG, "onCreate() complete");
+    }
+
+    public void setContentView(View view, ViewGroup.LayoutParams lp) {
+        super.setContentView(view, lp);
+
+        // EdgeToEdge.enable calls Window.setStatusBarColor, but that has no effect when
+        // targeting API level 35 and higher, so we need to manually draw the status bar
+        // background (https://stackoverflow.com/q/78832208).
+        View statusBarBackground = new View(this);
+        statusBarBackground.setBackgroundColor(getColor(R.color.colorPrimaryDark));
+        addContentView(
+            statusBarBackground,
+            new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0)
+        );
+
+        // Based on the "Empty Views Activity" from Android Studio Quail 3.
+        ViewCompat.setOnApplyWindowInsetsListener(
+            view,
+            (v, insets) -> {
+                // systemBars includes the status bar, navigation bar (which may be on
+                // the left or right on API level 28 and older), and action bar.
+                Insets systemBars = insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars()
+                    | WindowInsetsCompat.Type.displayCutout()
+                );
+                ((ViewGroup.MarginLayoutParams) v.getLayoutParams()).setMargins(
+                    systemBars.left, systemBars.top, systemBars.right, systemBars.bottom
+                );
+
+                ViewGroup.MarginLayoutParams statusLp =
+                    (ViewGroup.MarginLayoutParams) statusBarBackground.getLayoutParams();
+                statusLp.height = systemBars.top;
+                statusLp.setMargins(systemBars.left, 0, systemBars.right, 0);
+                statusBarBackground.requestLayout();
+
+                return insets;
+            }
+        );
     }
 
     protected void onStart() {

--- a/{{ cookiecutter.format }}/build.gradle
+++ b/{{ cookiecutter.format }}/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:9.3.1'
         classpath 'com.chaquo.python:gradle:17.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/{{ cookiecutter.format }}/gradle.properties
+++ b/{{ cookiecutter.format }}/gradle.properties
@@ -13,11 +13,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 # Disable the Gradle welcome message that prints for gradle's first run.
 org.gradle.welcome=never
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/{{ cookiecutter.format }}/gradle/wrapper/gradle-wrapper.properties
+++ b/{{ cookiecutter.format }}/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip


### PR DESCRIPTION
* The target API level update closes https://github.com/beeware/toga/issues/3637.

* The Gradle update adds compatibility with Java 25, while keeping compatibility with older versions as far back as 17.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
