### PR TITLE
Drop Python 3.10, add 3.15.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
       fail-fast: false
       matrix:
         runner-os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.11", "3.12", "3.13", "3.14", "3.15" ]
         framework: [ "toga" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
       - id: check-case-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: v0.2.60
+    hooks:
+      - id: rumdl
+      - id: rumdl-fmt
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ However, if you *do* want use this template directly...
     $ cookiecutter https://github.com/beeware/briefcase-android-gradle-template
     ```
 
-    This will ask you for a number of details of your application, including the name of your application (which should be a valid PyPI identifier), and the Formal Name of your application (the full name you use to describe your app). The remainder of these instructions will assume a name of `my-project`, and a formal name of `My Project`.
+    This will ask you for a number of details of your application, including the name of your application (which should be a valid PyPI identifier), and the formal name of your application (the full name you use to describe your app). The remainder of these instructions will assume a name of `my-project`, and a formal name of `My Project`.
 
 3. Add your code to the template, into the `My Project/app/src/main/python` directory. At the very minimum, you need to have an `<app name>/__main__.py` file that invokes `org.beeware.android.MainActivity.setPythonApp()`, providing an `IPythonApp` instance. This provides the hooks into the Android application lifecycle (`onCreate`, `onResume` and so on); it's up to you what your code does with those lifecycle hooks.
 

--- a/README.md
+++ b/README.md
@@ -28,30 +28,32 @@ However, if you *do* want use this template directly...
 
 If you've done this correctly, a project with a formal name of `My Project`, with an app name of `my-project` should have a directory structure that looks something like:
 
-    My Project/
-        app/
-            src/
-                main/
-                    python/
-                        my_project/
-                            __init__.py
-                            __main__.py (declares IPythonApp)
-                cpp/
-                    ...
-                java/
-                    ...
-                res/
-                    ...
-                AndroidManifest.xml
-            build.gradle
-            proguard-rules.pro
-            requirements.txt
-        briefcase.toml
+```text
+My Project/
+    app/
+        src/
+            main/
+                python/
+                    my_project/
+                        __init__.py
+                        __main__.py (declares IPythonApp)
+            cpp/
+                ...
+            java/
+                ...
+            res/
+                ...
+            AndroidManifest.xml
         build.gradle
-        gradle.properties
-        gradlew
-        gradlew.bat
-        settings.gradle
+        proguard-rules.pro
+        requirements.txt
+    briefcase.toml
+    build.gradle
+    gradle.properties
+    gradlew
+    gradlew.bat
+    settings.gradle
+```
 
 You're now ready to build and run your project! Either open the `My Project` directory in Android Studio, or [use the command line tools](https://developer.android.com/studio/build/building-cmdline).
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ The easiest way to use this project is to not use it at all - at least, not dire
 
 However, if you *do* want use this template directly...
 
-1.  Install [cookiecutter](https://github.com/cookiecutter/cookiecutter). This is a tool used to bootstrap complex project templates:
+1. Install [cookiecutter](https://github.com/cookiecutter/cookiecutter). This is a tool used to bootstrap complex project templates:
 
-        $ pip install cookiecutter
+    ```console
+    $ pip install cookiecutter
+    ```
 
-2.  Run `cookiecutter` on the template:
+2. Run `cookiecutter` on the template:
 
-        $ cookiecutter https://github.com/beeware/briefcase-android-gradle-template
+    ```console
+    $ cookiecutter https://github.com/beeware/briefcase-android-gradle-template
+    ```
 
     This will ask you for a number of details of your application, including the name of your application (which should be a valid PyPI identifier), and the Formal Name of your application (the full name you use to describe your app). The remainder of these instructions will assume a name of `my-project`, and a formal name of `My Project`.
 
-3.  Add your code to the template, into the `My Project/app/src/main/python` directory. At the very minimum, you need to have an `<app name>/__main__.py` file that invokes `org.beeware.android.MainActivity.setPythonApp()`, providing an `IPythonApp` instance. This provides the hooks into the Android application lifecycle (`onCreate`, `onResume` and so on); it's up to you what your code does with those lifecycle hooks.
+3. Add your code to the template, into the `My Project/app/src/main/python` directory. At the very minimum, you need to have an `<app name>/__main__.py` file that invokes `org.beeware.android.MainActivity.setPythonApp()`, providing an `IPythonApp` instance. This provides the hooks into the Android application lifecycle (`onCreate`, `onResume` and so on); it's up to you what your code does with those lifecycle hooks.
 
     If your code has any dependencies, they should be listed in the file `My Project/app/requirements.txt`.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 # Briefcase Android Gradle Template
 
-A [Cookiecutter](https://github.com/cookiecutter/cookiecutter/) template
-for building Python apps that will run under Android.
+A [Cookiecutter](https://github.com/cookiecutter/cookiecutter/) template for building Python apps that will run under Android.
 
 ## Using this template
 
-The easiest way to use this project is to not use it at all - at least,
-not directly. [Briefcase](https://github.com/beeware/briefcase/) is a
-tool that uses this template, rolling it out using data extracted from a
-`pyproject.toml` configuration file.
+The easiest way to use this project is to not use it at all - at least, not directly. [Briefcase](https://github.com/beeware/briefcase/) is a tool that uses this template, rolling it out using data extracted from a `pyproject.toml` configuration file.
 
 However, if you *do* want use this template directly...
 
-1.  Install
-    [cookiecutter](https://github.com/cookiecutter/cookiecutter). This
-    is a tool used to bootstrap complex project templates:
+1.  Install [cookiecutter](https://github.com/cookiecutter/cookiecutter). This is a tool used to bootstrap complex project templates:
 
         $ pip install cookiecutter
 
@@ -22,27 +16,13 @@ However, if you *do* want use this template directly...
 
         $ cookiecutter https://github.com/beeware/briefcase-android-gradle-template
 
-    This will ask you for a number of details of your application,
-    including the name of your application (which should be a valid
-    PyPI identifier), and the Formal Name of your application (the
-    full name you use to describe your app). The remainder of these
-    instructions will assume a name of `my-project`, and a formal name
-    of `My Project`.
+    This will ask you for a number of details of your application, including the name of your application (which should be a valid PyPI identifier), and the Formal Name of your application (the full name you use to describe your app). The remainder of these instructions will assume a name of `my-project`, and a formal name of `My Project`.
 
-3.  Add your code to the template, into the
-    `My Project/app/src/main/python` directory. At the very minimum, you
-    need to have an `<app name>/__main__.py` file that invokes
-    `org.beeware.android.MainActivity.setPythonApp()`, providing an
-    `IPythonApp` instance. This provides the hooks into the Android
-    application lifecycle (`onCreate`, `onResume` and so on); it's up to
-    you what your code does with those lifecycle hooks.
+3.  Add your code to the template, into the `My Project/app/src/main/python` directory. At the very minimum, you need to have an `<app name>/__main__.py` file that invokes `org.beeware.android.MainActivity.setPythonApp()`, providing an `IPythonApp` instance. This provides the hooks into the Android application lifecycle (`onCreate`, `onResume` and so on); it's up to you what your code does with those lifecycle hooks.
 
-    If your code has any dependencies, they should be listed in the file
-    `My Project/app/requirements.txt`.
+    If your code has any dependencies, they should be listed in the file `My Project/app/requirements.txt`.
 
-If you've done this correctly, a project with a formal name of
-`My Project`, with an app name of `my-project` should have a directory
-structure that looks something like:
+If you've done this correctly, a project with a formal name of `My Project`, with an app name of `my-project` should have a directory structure that looks something like:
 
     My Project/
         app/
@@ -69,24 +49,12 @@ structure that looks something like:
         gradlew.bat
         settings.gradle
 
-You're now ready to build and run your project! Either open the
-`My Project` directory in Android Studio, or [use the command line
-tools](https://developer.android.com/studio/build/building-cmdline).
+You're now ready to build and run your project! Either open the `My Project` directory in Android Studio, or [use the command line tools](https://developer.android.com/studio/build/building-cmdline).
 
 ## Next steps
 
-Of course, running Python code isn't very interesting by itself - you'll
-be able to output to the console, and see that output in the Logcat, but
-if you tap the app icon on your phone, you won't see anything - because
-there isn't a visible console on an Android.
+Of course, running Python code isn't very interesting by itself - you'll be able to output to the console, and see that output in the Logcat, but if you tap the app icon on your phone, you won't see anything - because there isn't a visible console on an Android.
 
-To do something interesting, you'll need to work with the native Android
-system libraries to draw widgets and respond to screen taps. The
-[Chaquopy](https://chaquo.com/chaquopy/) Java bridging library can be
-used to interface with the Android system libraries.
+To do something interesting, you'll need to work with the native Android system libraries to draw widgets and respond to screen taps. The [Chaquopy](https://chaquo.com/chaquopy/) Java bridging library can be used to interface with the Android system libraries.
 
-Alternatively, you could use a cross-platform widget toolkit that
-supports Android (such as
-[Toga](https://beeware.org/project/projects/libraries/toga)) to provide
-a GUI for your application. Toga automatically handles creating the
-`IPythonApp` instance and responding to the app's lifecycle hooks.
+Alternatively, you could use a cross-platform widget toolkit that supports Android (such as [Toga](https://beeware.org/project/projects/libraries/toga)) to provide a GUI for your application. Toga automatically handles creating the `IPythonApp` instance and responding to the app's lifecycle hooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.rumdl]
+flavor = "mkdocs"
+include = ["**/*.md"]
+exclude = ["comment.md", "CODE_OF_CONDUCT.md"]
+respect-gitignore = true
+force-exclude = true
+
+# Disable rules:
+# MD014: Forces commands in codeblocks to show output
+# MD042: Empty link - buggy, still flagging on valid MkDocs formatting
+# MD052: Reference link not found - buggy, flagging on valis MkDocs links
+disable = ["MD014", "MD042", "MD052"]
+
+[tool.rumdl.MD007]
+indent = 4
+
+[tool.rumdl.MD013]  # Line length
+line_length = 999999  # Force reflow to paragraph content to remove linebreaks
+reflow = true
+reflow_mode = "normalize"
+
+[tool.rumdl.MD026]  # Remove punctuation at the end of headings
+punctuation = ",;:"
+
+[tool.rumdl.MD033]  # No inline HTML
+allowed_elements = ["nospell",]  # pyspelling inline disable tag
+
+[tool.rumdl.MD046]
+style = "fenced"


### PR DESCRIPTION
Drop Python 3.10 from the test matrix; add 3.15

Also adds a rumdl configuration to ensure formatting on markdown.

3.15 CI jobs will fail until Chaquopy has 3.15 support.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
